### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 Backlog API へのアクセスを提供する MCP サーバーです。プロジェクト管理、課題追跡、ファイル操作などの機能を利用できます。
 
+<a href="https://glama.ai/mcp/servers/@tmhr1850/backlog-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tmhr1850/backlog-mcp-server/badge" alt="Backlog Server MCP server" />
+</a>
+
 ## 機能
 
 - **プロジェクト管理**: プロジェクト一覧の取得、詳細情報の閲覧
-- **課題管理**: 課題の作成、更新、検索、コメント追加
+- **課題管理**:課題の作成、更新、検索、コメント追加
 - **ユーザー管理**: ユーザー情報の取得
 - **ファイル操作**: 添付ファイルの管理
 - **コメント機能**: 課題へのコメント追加


### PR DESCRIPTION
This PR adds a badge for the [Backlog MCP Server](https://glama.ai/mcp/servers/@tmhr1850/backlog-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tmhr1850/backlog-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tmhr1850/backlog-mcp-server/badge" alt="Backlog Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.